### PR TITLE
Fix Rust benchmark for force-field, minor code change

### DIFF
--- a/force-field/rust/particle.rs
+++ b/force-field/rust/particle.rs
@@ -18,15 +18,12 @@ impl Particle {
   }
 
   pub fn force_from(&self, other: &Particle) -> Vector {
-    let distance = self.position - other.position;
+    let distance = other.position - self.position;
 
     // G*m1*m1/d^2, assuming G=1
     let magnitude = self.mass * other.mass / distance.dot(&distance);
 
-    let mut vector = distance.normalize();
-    vector.scale(magnitude);
-
-    vector
+    magnitude * distance.normalize()
   }
 
   pub fn apply_force(&mut self, force: Vector, time_delta: f64) {

--- a/force-field/rust/vector.rs
+++ b/force-field/rust/vector.rs
@@ -26,11 +26,6 @@ impl Vector {
     self.x * v.x + self.y * v.y
   }
 
-  pub fn scale(&mut self, factor: f64) {
-    self.x *= factor;
-    self.y *= factor;
-  }
-
   pub fn normalize(&self) -> Vector {
     let magnitude = self.dot(&self).sqrt();
 
@@ -38,10 +33,7 @@ impl Vector {
       return Vector::new();
     }
 
-    let mut vector = self.clone();
-    vector.scale(1f64 / magnitude);
-
-    vector
+    (1f64 / magnitude) * *self
   }
 }
 


### PR DESCRIPTION
A fix for #6 .

Fixed the distance calculation being the other way around, giving incorrect results. This fixed the Rust benchmark and makes it consistent with the other benchmarks.

This PR also simplified vector scale calculations.