### PR TITLE
Improved Rust examples

### DIFF
--- a/array-reverse/rust/main.rs
+++ b/array-reverse/rust/main.rs
@@ -1,11 +1,9 @@
 use std::env::args;
 
 fn reverse_array(the_list: &mut Vec<usize>) {
-  for i in 0..the_list.len() >> 1 {
+  for i in 0..the_list.len() / 2 {
     let last_idx = the_list.len() - i - 1;
-    let last_value = the_list[last_idx];
-    the_list[last_idx] = the_list[i];
-    the_list[i] = last_value;
+    the_list.swap(i, last_idx);
   }
 }
 

--- a/roll-avg/rust/main.rs
+++ b/roll-avg/rust/main.rs
@@ -1,13 +1,7 @@
 use std::env::args;
 
 fn add_up_to(dest: usize) -> usize {
-  let mut sum: usize = 0;
-
-  for i in 1..dest + 1 {
-    sum += i;
-  }
-
-  sum
+  (1..dest + 1).sum()
 }
 
 fn roll_average(dest: usize) -> f64 {


### PR DESCRIPTION
I improved the Rust examples a bit.

You have to watch out for the following things:

- Indexing (`array[i]`) is bounds-checked in Rust. By using iterators / built-in functions, these bounds-checks can be elided (with unsafe code). This makes the code shorter and faster.
- Please do not use `value >> 1` as an "optimization" for `value / 2`. It's a trivial optimization that is done by compilers since the 90s.

You did not state what computer (specs) these tests were run on, but the array-revers runs slightly faster (5.1 seconds instead of 5.6 seconds) afterwards. roll-avg is the same, it's just cleaner code.